### PR TITLE
Narrowed icons to 8px

### DIFF
--- a/git-gutter-fringe.el
+++ b/git-gutter-fringe.el
@@ -46,36 +46,34 @@
   :group 'git-gutter)
 
 (fringe-helper-define 'git-gutter-fr:added nil
-                      "...XXX..."
-                      "...XXX..."
-                      "...XXX..."
-                      "XXXXXXXXX"
-                      "XXXXXXXXX"
-                      "XXXXXXXXX"
-                      "...XXX..."
-                      "...XXX..."
-                      "...XXX...")
+  "...XX..."
+  "...XX..."
+  "...XX..."
+  "XXXXXXXX"
+  "XXXXXXXX"
+  "...XX..."
+  "...XX..."
+  "...XX...")
 
 (fringe-helper-define 'git-gutter-fr:deleted nil
-                      "........."
-                      "........."
-                      "........."
-                      "XXXXXXXXX"
-                      "XXXXXXXXX"
-                      "XXXXXXXXX"
-                      "........."
-                      "........."
-                      ".........")
+  "........"
+  "........"
+  "........"
+  "XXXXXXXX"
+  "XXXXXXXX"
+  "........"
+  "........"
+  "........")
 
 (fringe-helper-define 'git-gutter-fr:modified nil
-                      "........."
-                      "..XXXXX.."
-                      "..XXXXX.."
-                      "..XXXXX.."
-                      "..XXXXX.."
-                      "..XXXXX.."
-                      "..XXXXX.."
-                      ".........")
+  "........"
+  "..XXXX.."
+  "..XXXX.."
+  "..XXXX.."
+  "..XXXX.."
+  "..XXXX.."
+  "..XXXX.."
+  "........")
 
 (defun git-gutter-fr:select-sign (type)
   (case type


### PR DESCRIPTION
Emacs doesn't seem to support fringe icons wider than 8px - they get cropped. These work better.
