### PR TITLE
Fix fringe overlay deletion

### DIFF
--- a/git-gutter-fringe.el
+++ b/git-gutter-fringe.el
@@ -126,7 +126,8 @@
   (setq git-gutter-fr:bitmap-references nil))
 
 (setq git-gutter:view-diff-function 'git-gutter-fr:view-diff-infos
-      git-gutter:clear-function     'git-gutter-fr:clear)
+      git-gutter:clear-function 'git-gutter-fr:clear
+      git-gutter:window-config-change-function nil)
 
 (provide 'git-gutter-fringe)
 


### PR DESCRIPTION
This set of patches fixes ALL issues with fringe overlays not getting deleted properly.

[Here's the patch](https://github.com/nschum/fringe-helper.el/commit/ed90d71d4a4c3a8515cdfb9ebe4d0d7be5953eba) to fringe-helper.el that this pull request depends on. It's included in the latest [MELPA](http://melpa.milkbox.net/) release (20130427.1608).

**Please note:**
1. Commit `Remove unneded init function` depends on [patch set 3.) in git-gutter](https://github.com/syohex/emacs-git-gutter/pull/30).
2. Commit `Set 'git-gutter:window-config-change-function' to nil` depends on [patch set 4.) in git-gutter](https://github.com/syohex/emacs-git-gutter/pull/30).
