### PR TITLE
make faces inherit from git-gutter

### DIFF
--- a/git-gutter-fringe.el
+++ b/git-gutter-fringe.el
@@ -42,17 +42,17 @@
 (require 'fringe-helper)
 
 (defface git-gutter-fr:modified
-    '((t (:foreground "magenta" :weight bold)))
+    '((t (:inherit git-gutter:modified)))
   "Face of modified"
   :group 'git-gutter)
 
 (defface git-gutter-fr:added
-    '((t (:foreground "green" :weight bold)))
+    '((t (:inherit git-gutter:added)))
   "Face of added"
   :group 'git-gutter)
 
 (defface git-gutter-fr:deleted
-    '((t (:foreground "red" :weight bold)))
+    '((t (:inherit git-gutter:deleted)))
   "Face of deleted"
   :group 'git-gutter)
 


### PR DESCRIPTION
Rather than having identical definition in 2 places, just have
git-gutter-fr faces inherit from their git-gutter counterparts. This
will also allow theme designers to support both modes more easily
without breaking anyone's personal changes if they've defined the fringe
faces and not the git-gutter versions (or for some reason actually want
to have different values for the two different modes).
