### PR TITLE
Fix git-gutter-fr:clear

### DIFF
--- a/git-gutter-fringe.el
+++ b/git-gutter-fringe.el
@@ -148,7 +148,14 @@
 
 (defun git-gutter-fr:clear ()
   (dolist (ov (overlays-in (point-min) (point-max)))
-    (when (overlay-get ov 'git-gutter)
+    (when (or (overlay-get ov 'git-gutter)
+              (let ((parent (overlay-get ov 'fringe-helper-parent)))
+                (and parent
+                     (or
+                      ;; Parent has been deleted
+                      (null (overlay-buffer parent))
+                      ;; or parent was created by git-gutter
+                      (overlay-get parent 'git-gutter)))))
       (delete-overlay ov)))
   (setq git-gutter-fr:bitmap-references nil))
 


### PR DESCRIPTION
Since the function `fringe-helper-modification-func` is contained in `modification-hooks` of the return value of `fringe-helper-insert-region` and `fringe-helper-modification-func` may create new overlays, it is not sufficient to remove overlays which have the `git-gutter` property to remove all overlays created by `git-gutter-fringe`.

Merging this pull request will fix `git-gutter-fr:clear` and issue #23.
