### PR TITLE
Inherit from both fringe and git-gutter faces

### DIFF
--- a/git-gutter-fringe.el
+++ b/git-gutter-fringe.el
@@ -44,17 +44,17 @@
 (require 'fringe-helper)
 
 (defface git-gutter-fr:modified
-    '((t (:inherit git-gutter:modified)))
+    '((t (:inherit (fringe git-gutter:modified))))
   "Face of modified"
   :group 'git-gutter)
 
 (defface git-gutter-fr:added
-    '((t (:inherit git-gutter:added)))
+    '((t (:inherit (fringe git-gutter:added))))
   "Face of added"
   :group 'git-gutter)
 
 (defface git-gutter-fr:deleted
-    '((t (:inherit git-gutter:deleted)))
+    '((t (:inherit (fringe git-gutter:deleted))))
   "Face of deleted"
   :group 'git-gutter)
 


### PR DESCRIPTION
Current faces seems to break fringe looks slightly. So, I make the faces to inherit from fringe at first to overwrite the background of git-gutter faces.

Before
--------------
![a](https://cloud.githubusercontent.com/assets/29692/21379888/b659aac4-c794-11e6-840a-42e86e3ffd95.png)

After
--------------
![b](https://cloud.githubusercontent.com/assets/29692/21379890/b65ffda2-c794-11e6-8612-f3f03d33d3f2.png)
