### PR TITLE
Prioritize git-gutter faces over fringe face in inheritance

### DIFF
--- a/git-gutter-fringe.el
+++ b/git-gutter-fringe.el
@@ -44,17 +44,17 @@
 (require 'fringe-helper)
 
 (defface git-gutter-fr:modified
-    '((t (:inherit (fringe git-gutter:modified))))
+    '((t (:inherit (git-gutter:modified fringe))))
   "Face of modified"
   :group 'git-gutter)
 
 (defface git-gutter-fr:added
-    '((t (:inherit (fringe git-gutter:added))))
+    '((t (:inherit (git-gutter:added fringe))))
   "Face of added"
   :group 'git-gutter)
 
 (defface git-gutter-fr:deleted
-    '((t (:inherit (fringe git-gutter:deleted))))
+    '((t (:inherit (git-gutter:deleted fringe))))
   "Face of deleted"
   :group 'git-gutter)
 


### PR DESCRIPTION
This change prioritises the git-gutter faces when inheriting from fringe. In other words, when face properties are both set by a git-gutter face and fringe, the git-gutter property is preferred. For example, if both the git-gutter face and fringe sets the `foreground` property, then the specific git gutter face foreground will be used. Previously, the same foreground colour would apply to each face (added, deleted, and modified) making them look the same.

Fixes #30.